### PR TITLE
Don't use 3rd party string conversion

### DIFF
--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -1,4 +1,3 @@
-from builtins import str
 from datetime import datetime
 import logging
 
@@ -64,7 +63,7 @@ class PythonOperator(BaseOperator):
             self.op_kwargs = context
 
         return_value = self.python_callable(*self.op_args, **self.op_kwargs)
-        logging.info("Done. Returned value was: " + str(return_value))
+        logging.info("Done. Returned value was: %s", return_value)
         return return_value
 
 


### PR DESCRIPTION
## Changes

This is a backport of a bugfix in Airflow 1.9. Instead of doing `'message' + str(return_value)` it uses string interpolation to convert the operator's return value into a string.

## Background

Because Python 2 doesn't distinguish between binary data and strings, the call to [`future.newstr`](http://python-future.org/str_object.html) here* tries to convert the return value into an ASCII string. If the return value doesn't contain ASCII-compatible binary data, we get this crash:

```
[2018-04-28 05:01:40,008] {models.py:1286} ERROR - 'ascii' codec can't decode byte 0x8b in position 1: ordinal not in range(128)
Traceback (most recent call last):
  File "/apps/airflow/local/lib/python2.7/site-packages/airflow/models.py", line 1245, in run
    result = task_copy.execute(context=context)
  File "/apps/airflow/local/lib/python2.7/site-packages/airflow/operators/python_operator.py", line 67, in execute
    logging.info("Done. Returned value was: " + str(return_value))
  File "/apps/airflow/local/lib/python2.7/site-packages/future/types/newstr.py", line 102, in __new__
    return super(newstr, cls).__new__(cls, value)
UnicodeDecodeError: 'ascii' codec can't decode byte 0x8b in position 1: ordinal not in range(128)
```

This PR will use the native string conversion, which doesn't exhibit the problem on Python 2. 

<sub>*Aliased to `builtins.str`</sub>